### PR TITLE
Cari tahu kenapa pemain non-real muncul lagi

### DIFF
--- a/app/lobby/page.tsx
+++ b/app/lobby/page.tsx
@@ -39,25 +39,28 @@ export default function LobbyPage() {
     const parsedData = JSON.parse(data);
     setPemainData(parsedData);
 
-    // Simulasi pemain lain (nanti bisa dari WebSocket)
-    setPemainLain([
-      { nama: 'Budi', tim: 'merah', masukAt: new Date().toISOString() },
-      { nama: 'Sari', tim: 'putih', masukAt: new Date().toISOString() },
-      { nama: 'Rudi', tim: 'merah', masukAt: new Date().toISOString() },
-      { nama: 'Dewi', tim: 'putih', masukAt: new Date().toISOString() },
-    ]);
+    const enableDummy = process.env.NEXT_PUBLIC_ENABLE_DUMMY === '1';
+    if (enableDummy) {
+      // Simulasi pemain lain (opsional untuk demo)
+      setPemainLain([
+        { nama: 'Budi', tim: 'merah', masukAt: new Date().toISOString() },
+        { nama: 'Sari', tim: 'putih', masukAt: new Date().toISOString() },
+        { nama: 'Rudi', tim: 'merah', masukAt: new Date().toISOString() },
+        { nama: 'Dewi', tim: 'putih', masukAt: new Date().toISOString() },
+      ]);
 
-    // Simulasi pertanyaan dari game master (nanti bisa dari WebSocket)
-    setTimeout(() => {
-      setPertanyaan({
-        id: '1',
-        pertanyaan: 'Apa ibukota Indonesia?',
-        pilihan: ['Jakarta', 'Bandung', 'Surabaya', 'Yogyakarta'],
-        waktu: 30
-      });
-      setStatus('pertanyaan');
-      setWaktuTersisa(30);
-    }, 5000);
+      // Simulasi pertanyaan dari game master (opsional untuk demo)
+      setTimeout(() => {
+        setPertanyaan({
+          id: '1',
+          pertanyaan: 'Apa ibukota Indonesia?',
+          pilihan: ['Jakarta', 'Bandung', 'Surabaya', 'Yogyakarta'],
+          waktu: 30
+        });
+        setStatus('pertanyaan');
+        setWaktuTersisa(30);
+      }, 5000);
+    }
   }, [router]);
 
   useEffect(() => {

--- a/app/lomba/page.tsx
+++ b/app/lomba/page.tsx
@@ -441,6 +441,7 @@ const LombaPageContent = () => {
           onReady={handleSocketReady}
           onBattleStart={handleBattleStart}
           onBattleEnd={handleBattleEnd}
+          onLobbyUpdate={handleLobbyUpdate}
         />
       )}
     </div>

--- a/components/SocketManager.tsx
+++ b/components/SocketManager.tsx
@@ -43,6 +43,7 @@ interface SocketManagerProps {
   onBattleStart?: (battleData: Battle) => void;
   onBattleEnd?: (result: any) => void;
   onLiveAnswer?: (answerData: LiveAnswer) => void;
+  onLobbyUpdate?: (data: { players: User[]; count: number }) => void;
 }
 
 export interface SocketManagerRef {
@@ -54,7 +55,7 @@ export interface SocketManagerRef {
 }
 
 const SocketManager = forwardRef<SocketManagerRef, SocketManagerProps>(
-  ({ user, onReady, onBattleStart, onBattleEnd, onLiveAnswer }, ref) => {
+  ({ user, onReady, onBattleStart, onBattleEnd, onLiveAnswer, onLobbyUpdate }, ref) => {
     const [socket, setSocket] = useState<Socket | null>(null);
     const [isConnected, setIsConnected] = useState(false);
     const [connectionAttempts, setConnectionAttempts] = useState(0);
@@ -195,6 +196,11 @@ const SocketManager = forwardRef<SocketManagerRef, SocketManagerProps>(
         // Lobby events
         newSocket.on('lobby-update', (data: any) => {
           console.log('👥 Lobby updated:', data);
+          try {
+            onLobbyUpdate?.(data);
+          } catch (error) {
+            console.error('Error in lobby-update handler:', error);
+          }
         });
 
         // Spectator events


### PR DESCRIPTION
Remove hardcoded dummy players and enable real-time lobby updates to prevent "non-real" players from appearing.

The `app/lobby/page.tsx` previously seeded dummy player data directly, which is now gated behind `NEXT_PUBLIC_ENABLE_DUMMY`. Additionally, the `app/lomba/page.tsx` (participants list) was not receiving real-time updates, leading to a desynchronized view of active players. This is fixed by passing an `onLobbyUpdate` callback through `SocketManager` to ensure the player list is always current.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddd1000f-8ed3-4183-bcc5-f2fef6e8704b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ddd1000f-8ed3-4183-bcc5-f2fef6e8704b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

